### PR TITLE
Node.js v18 (clang) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is a [Node.js](https://nodejs.org/en/) module available through the
 [npm registry](https://www.npmjs.com/).
 -->
 
-Node.js v14.0 for z/OS or higher is required.
+IBM SDK for Node.js - z/OS 14.0 or IBM Open Enterprise SDK for Node.js 16 or higher is required.
 
 ## Simple to use
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is a [Node.js](https://nodejs.org/en/) module available through the
 [npm registry](https://www.npmjs.com/).
 -->
 
-Node.js 8.16.0 for z/OS or higher is required.
+Node.js v14.0 for z/OS or higher is required.
 
 ## Simple to use
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -17,8 +17,7 @@
         "dependencies": [
             "<!(node -p \"require('node-addon-api').gyp\")"
         ],
-        "cflags": [  "-I../include" ],
-        "defines": [ "NAPI_DISABLE_CPP_EXCEPTIONS", "_AE_BIMODAL=1", "_ALL_SOURCE", "_ENHANCED_ASCII_EXT=0x42020010", "_LARGE_TIME_API", "_OPEN_MSGQ_EXT", "_OPEN_SYS_FILE_EXT=1", "_OPEN_SYS_SOCK_IPV6", "_UNIX03_SOURCE", "_UNIX03_THREADS", "_UNIX03_WITHDRAWN", "_XOPEN_SOURCE=600", "_XOPEN_SOURCE_EXTENDED", 
-        ]
+        "cflags": [  "-I/usr/lpp/gskssl/include" ],
+        "defines": [ "NAPI_DISABLE_CPP_EXCEPTIONS" ],
     }]
 }

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,10 +1,6 @@
 {
     "targets": [{
         "target_name": "zcrypto",
-        "cflags!": [ "-fno-exceptions"],
-        "cflags": [  "-qascii" ],
-        "cflags_cc!": ["-fno-exceptions" ],
-        "cflags_cc": ["-qascii" ],
         "include_dirs": [
             "<!@(node -p \"require('node-addon-api').include\")"
         ],
@@ -21,6 +17,7 @@
         "dependencies": [
             "<!(node -p \"require('node-addon-api').gyp\")"
         ],
+        "cflags": [  "-I../include" ],
         "defines": [ "NAPI_DISABLE_CPP_EXCEPTIONS", "_AE_BIMODAL=1", "_ALL_SOURCE", "_ENHANCED_ASCII_EXT=0x42020010", "_LARGE_TIME_API", "_OPEN_MSGQ_EXT", "_OPEN_SYS_FILE_EXT=1", "_OPEN_SYS_SOCK_IPV6", "_UNIX03_SOURCE", "_UNIX03_THREADS", "_UNIX03_WITHDRAWN", "_XOPEN_SOURCE=600", "_XOPEN_SOURCE_EXTENDED", 
         ]
     }]

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,4 +1,7 @@
 {
+    "variables": {
+        "NODE_VERSION%":"<!(node -p \"process.versions.node.split(\\\".\\\")[0]\")"
+    },
     "targets": [{
         "target_name": "zcrypto",
         "include_dirs": [
@@ -11,6 +14,10 @@
                "zcrypto_impl.cc"
             ],
           }],
+          [ "NODE_VERSION < 18", {
+            "cflags": [  "-qascii" ],
+            "cflags_cc": [ "-qascii" ]
+          }],
         ],
 
         "libraries": ["/usr/lib/GSKCMS64.x", "/usr/lib/GSKSSL64.x"],
@@ -18,6 +25,6 @@
             "<!(node -p \"require('node-addon-api').gyp\")"
         ],
         "cflags": [  "-I/usr/lpp/gskssl/include" ],
-        "defines": [ "NAPI_DISABLE_CPP_EXCEPTIONS" ],
+        "defines": [ "NAPI_DISABLE_CPP_EXCEPTIONS", "_OPEN_SYS_FILE_EXT" ],
     }]
 }

--- a/binding.gyp
+++ b/binding.gyp
@@ -14,9 +14,8 @@
                "zcrypto_impl.cc"
             ],
           }],
-          [ "NODE_VERSION < 18", {
-            "cflags": [  "-qascii" ],
-            "cflags_cc": [ "-qascii" ]
+          [ "NODE_VERSION < 16", {
+            "cflags": [  "-qascii" ]
           }],
         ],
 

--- a/example.js
+++ b/example.js
@@ -1,6 +1,6 @@
 /*
  * Licensed Materials - Property of IBM
- * (C) Copyright IBM Corp. 2020. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2022. All Rights Reserved.
  * US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
 */
 

--- a/examples/client.js
+++ b/examples/client.js
@@ -1,6 +1,6 @@
 /*
  * Licensed Materials - Property of IBM
- * (C) Copyright IBM Corp. 2020. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2022. All Rights Reserved.
  * US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
 */
 

--- a/examples/kdb.js
+++ b/examples/kdb.js
@@ -1,6 +1,6 @@
 /*
  * Licensed Materials - Property of IBM
- * (C) Copyright IBM Corp. 2020. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2022. All Rights Reserved.
  * US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
 */
 const zcrypto = require('./');

--- a/examples/keyring.js
+++ b/examples/keyring.js
@@ -1,6 +1,6 @@
 /*
  * Licensed Materials - Property of IBM
- * (C) Copyright IBM Corp. 2020. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2022. All Rights Reserved.
  * US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
 */
 const zcrypto = require('./');

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 /*
  * Licensed Materials - Property of IBM
- * (C) Copyright IBM Corp. 2020. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2022. All Rights Reserved.
  * US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
 */
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
   "repository": "ibmruntimes/node-zcrypto",
   "keywords": [
     "zos",
-    "crypto"
+    "crypto",
+    "keyring",
+    "RACF"
   ],
   "dependencies": {
     "node-addon-api": "^1.6.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zcrypto",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "description": "A z/OS RACF keyring/kdb crypto npm for z/OS",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zcrypto",
-  "version": "1.4.0",
+  "version": "1.3.4",
   "description": "A z/OS RACF keyring/kdb crypto npm for z/OS",
   "main": "index.js",
   "scripts": {

--- a/test/kdb.js
+++ b/test/kdb.js
@@ -1,6 +1,6 @@
 /*
  * Licensed Materials - Property of IBM
- * (C) Copyright IBM Corp. 2020. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2022. All Rights Reserved.
  * US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
 */
 

--- a/zcrypto.cc
+++ b/zcrypto.cc
@@ -186,8 +186,6 @@ Napi::Value ZCrypto::ExportKeyToBuffer(const Napi::CallbackInfo &info) {
   if (rc != 0)
     return Napi::Number::New(env, rc);
 
-  char* bufferptr = nullptr;
-
   Napi::ArrayBuffer arrayBuffer = Napi::ArrayBuffer::New(env, (void*)(stream.data), stream.length);
   return Napi::Uint8Array::New(env, stream.length, arrayBuffer, 0);
 }
@@ -208,8 +206,6 @@ Napi::Value ZCrypto::ExportCertToBuffer(const Napi::CallbackInfo &info) {
 
   if (rc != 0)
     return Napi::Number::New(env, rc);
-
-  char* bufferptr = nullptr;
 
   Napi::ArrayBuffer arrayBuffer = Napi::ArrayBuffer::New(env, (void*)(stream.data), stream.length);
   return Napi::Uint8Array::New(env, stream.length, arrayBuffer, 0);

--- a/zcrypto.cc
+++ b/zcrypto.cc
@@ -1,6 +1,6 @@
 /*
  * Licensed Materials - Property of IBM
- * (C) Copyright IBM Corp. 2020. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2022. All Rights Reserved.
  * US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
  */
 

--- a/zcrypto.h
+++ b/zcrypto.h
@@ -1,6 +1,6 @@
 /*
  * Licensed Materials - Property of IBM
- * (C) Copyright IBM Corp. 2020. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2022. All Rights Reserved.
  * US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
  */
 

--- a/zcrypto.h
+++ b/zcrypto.h
@@ -7,11 +7,11 @@
 #ifndef __ZCRYPTO_H_
 #define __ZCRYPTO_H_ 1
 
-#include <stdio.h>
-#include <stdlib.h>
 #include <gskcms.h>
 #include <gskssl.h>
 #include <napi.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string>
 
 extern "C" int createKDB_impl( const char* filename, const char* password, int length, int expiration, gsk_handle* handle);

--- a/zcrypto_impl.cc
+++ b/zcrypto_impl.cc
@@ -1,6 +1,6 @@
 /*
  * Licensed Materials - Property of IBM
- * (C) Copyright IBM Corp. 2020. All Rights Reserved.
+ * (C) Copyright IBM Corp. 2022. All Rights Reserved.
  * US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
  */
 

--- a/zcrypto_impl.cc
+++ b/zcrypto_impl.cc
@@ -5,13 +5,12 @@
  */
 
 #include "zcrypto.h"
-#include <unistd.h>
-#include <sys/stat.h>
 #include <_Nascii.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 
 extern "C" int __chgfdccsid(int fd, unsigned short ccsid);
-
 
 extern "C" int createKDB_impl( const char* filename, const char* password, int length, int expiration, gsk_handle* handle) {
     std::string str; 


### PR DESCRIPTION
* Support for clang (removes -qascii) which is already in the Node.js product's common.gypi
* Removed unused variables
* Copyright updates 