### PR TITLE
update Node.js version prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ This is a [Node.js](https://nodejs.org/en/) module available through the
 [npm registry](https://www.npmjs.com/).
 -->
 
-IBM SDK for Node.js - z/OS 14.0 or IBM Open Enterprise SDK for Node.js 16 or higher is required.
+Before installing, [download and install IBM Open Enterprise SDK for Node.js](https://www.ibm.com/docs/en/sdk-nodejs-zos)
+16 or higher. zcrypto v1.4.0 or higher is required for Node.js 18 or higher.
 
 ## Simple to use
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zcrypto",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "A z/OS RACF keyring/kdb crypto npm for z/OS",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
commit 8478c786ae upgraded zcrypto to v1.4.0 and enabled zcrypto to build with clang.

Also include the link to the Node.js versions.