### PR TITLE
check and log errors from exposed export* APIs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+2025-08-07, Version 1.4.2
+
+* check and log errors from exposed `export*` APIs
+
+2024-01-30, Version 1.4.1
+
+* update Node.js version prerequisites
+
 2023-10-24, Version 1.4.0
 
 * implement new closeKDB API

--- a/index.js
+++ b/index.js
@@ -10,113 +10,113 @@ const zcrypto = require('./build/Release/zcrypto.node');
 
 // Helper functions
 function ArrayToString(array) {
-    var out, i, len, c;
-    out = "";
-    len = array.length;
-    i = 0;
-    while(i < len) {
-      c = array[i++];
-      out += String.fromCharCode(c);
-    }
+  var out, i, len, c;
+  out = "";
+  len = array.length;
+  i = 0;
+  while(i < len) {
+    c = array[i++];
+    out += String.fromCharCode(c);
+  }
 
-    return out;
+  return out;
 }
 
 function derToPem(der) {
-    var asnObj = forge.asn1.fromDer(der);
-    var asn1Cert = forge.pki.certificateFromAsn1(asnObj);
-    return forge.pki.certificateToPem(asn1Cert);
+  var asnObj = forge.asn1.fromDer(der);
+  var asn1Cert = forge.pki.certificateFromAsn1(asnObj);
+  return forge.pki.certificateToPem(asn1Cert);
 };
 
 
 function ConvertP12ToPKCS1(string, passphrase) {
-	var asn = forge.asn1.fromDer(string, false)
-	var p12 = forge.pkcs12.pkcs12FromAsn1(asn, false, passphrase);
-	var bags = p12.getBags({bagType: forge.pki.oids.certBag});
+  var asn = forge.asn1.fromDer(string, false)
+  var p12 = forge.pkcs12.pkcs12FromAsn1(asn, false, passphrase);
+  var bags = p12.getBags({bagType: forge.pki.oids.certBag});
 
-	var bag = bags[forge.pki.oids.certBag][0];
+  var bag = bags[forge.pki.oids.certBag][0];
 
-	var keyData = p12.getBags({ bagType: forge.pki.oids.pkcs8ShroudedKeyBag })[forge.pki.oids.pkcs8ShroudedKeyBag]
-			.concat(p12.getBags({ bagType: forge.pki.oids.keyBag })[forge.pki.oids.keyBag]);
-	var certBags = p12.getBags({ bagType: forge.pki.oids.certBag })[forge.pki.oids.certBag];
+  var keyData = p12.getBags({ bagType: forge.pki.oids.pkcs8ShroudedKeyBag })[forge.pki.oids.pkcs8ShroudedKeyBag]
+    .concat(p12.getBags({ bagType: forge.pki.oids.keyBag })[forge.pki.oids.keyBag]);
+  var certBags = p12.getBags({ bagType: forge.pki.oids.certBag })[forge.pki.oids.certBag];
 
-	var certificate = forge.pki.certificateToPem(certBags[0].cert);
+  var certificate = forge.pki.certificateToPem(certBags[0].cert);
 
-	var key = keyData.length ? forge.pki.privateKeyToPem(keyData[0].key) : undefined;
+  var key = keyData.length ? forge.pki.privateKeyToPem(keyData[0].key) : undefined;
 
-    const rsaPrivateKey = forge.pki.privateKeyToAsn1(keyData[0].key);
+  const rsaPrivateKey = forge.pki.privateKeyToAsn1(keyData[0].key);
 
-    var forgePublicKey = forge.pki.rsa.setPublicKey(keyData[0].key.n, keyData[0].key.e);
-    var publickey = forge.pki.publicKeyToPem(forgePublicKey);
+  var forgePublicKey = forge.pki.rsa.setPublicKey(keyData[0].key.n, keyData[0].key.e);
+  var publickey = forge.pki.publicKeyToPem(forgePublicKey);
 
-	return {
-        key: key,
-        cert: certificate,
-        publickey: publickey
-    };
+  return {
+    key: key,
+    cert: certificate,
+    publickey: publickey
+  };
 }
 
 function ConvertP12ToPKCS8(string, passphrase) {
-	var asn = forge.asn1.fromDer(string, false)
-	var p12 = forge.pkcs12.pkcs12FromAsn1(asn, false, passphrase);
-	var bags = p12.getBags({bagType: forge.pki.oids.certBag});
+  var asn = forge.asn1.fromDer(string, false)
+  var p12 = forge.pkcs12.pkcs12FromAsn1(asn, false, passphrase);
+  var bags = p12.getBags({bagType: forge.pki.oids.certBag});
 
-	var bag = bags[forge.pki.oids.certBag][0];
+  var bag = bags[forge.pki.oids.certBag][0];
 
-	var keyData = p12.getBags({ bagType: forge.pki.oids.pkcs8ShroudedKeyBag })[forge.pki.oids.pkcs8ShroudedKeyBag]
-			.concat(p12.getBags({ bagType: forge.pki.oids.keyBag })[forge.pki.oids.keyBag]);
-	var certBags = p12.getBags({ bagType: forge.pki.oids.certBag })[forge.pki.oids.certBag];
+  var keyData = p12.getBags({ bagType: forge.pki.oids.pkcs8ShroudedKeyBag })[forge.pki.oids.pkcs8ShroudedKeyBag]
+    .concat(p12.getBags({ bagType: forge.pki.oids.keyBag })[forge.pki.oids.keyBag]);
+  var certBags = p12.getBags({ bagType: forge.pki.oids.certBag })[forge.pki.oids.certBag];
 
-	var certificate = forge.pki.certificateToPem(certBags[0].cert);
+  var certificate = forge.pki.certificateToPem(certBags[0].cert);
 
-    // convert a Forge private key to an ASN.1 RSAPrivateKey
-    const rsaPrivateKey = forge.pki.privateKeyToAsn1(keyData[0].key);
+  // convert a Forge private key to an ASN.1 RSAPrivateKey
+  const rsaPrivateKey = forge.pki.privateKeyToAsn1(keyData[0].key);
 
-    // wrap an RSAPrivateKey ASN.1 object in a PKCS#8 ASN.1 PrivateKeyInfo
-    const privateKeyInfo = forge.pki.wrapRsaPrivateKey(rsaPrivateKey);
+  // wrap an RSAPrivateKey ASN.1 object in a PKCS#8 ASN.1 PrivateKeyInfo
+  const privateKeyInfo = forge.pki.wrapRsaPrivateKey(rsaPrivateKey);
 
-    // convert a PKCS#8 ASN.1 PrivateKeyInfo to PEM
-	var key = keyData.length ? forge.pki.privateKeyInfoToPem(privateKeyInfo) : undefined;
+  // convert a PKCS#8 ASN.1 PrivateKeyInfo to PEM
+  var key = keyData.length ? forge.pki.privateKeyInfoToPem(privateKeyInfo) : undefined;
 
-    var forgePublicKey = forge.pki.rsa.setPublicKey(keyData[0].key.n, keyData[0].key.e);
-    var publickey = forge.pki.publicKeyToPem(forgePublicKey);
+  var forgePublicKey = forge.pki.rsa.setPublicKey(keyData[0].key.n, keyData[0].key.e);
+  var publickey = forge.pki.publicKeyToPem(forgePublicKey);
 
-	return {
-        key: key,
-        cert: certificate,
-        publickey: publickey
-    };
+  return {
+    key: key,
+    cert: certificate,
+    publickey: publickey
+  };
 }
 
 
 function exportKeysToPKCS8(obj, label, passphrase = "root") {
-	var p12File = obj.exportKeyToBuffer(passphrase, label);
-	return ConvertP12ToPKCS8(ArrayToString(p12File), passphrase);
+  var p12File = obj.exportKeyToBuffer(passphrase, label);
+  return ConvertP12ToPKCS8(ArrayToString(p12File), passphrase);
 }
 
 function exportPublicKey(obj, label, passphrase = "root") {
-	var p12File = obj.exportKeyToBuffer(passphrase, label);
-	return ConvertP12ToPublicKey(ArrayToString(p12File), passphrase);
+  var p12File = obj.exportKeyToBuffer(passphrase, label);
+  return ConvertP12ToPublicKey(ArrayToString(p12File), passphrase);
 }
 
 function exportKeysToPKCS1(obj, label, passphrase = "root") {
-	var p12File = obj.exportKeyToBuffer(passphrase, label);
-	return ConvertP12ToPKCS1(ArrayToString(p12File), passphrase);
+  var p12File = obj.exportKeyToBuffer(passphrase, label);
+  return ConvertP12ToPKCS1(ArrayToString(p12File), passphrase);
 }
 
 function exportCertToPEM(obj, label) {
-	var stream = obj.exportCertToBuffer(label);
+  var stream = obj.exportCertToBuffer(label);
   if (typeof stream == "number" && stream != 0) {
     console.log("Error: " + obj.getErrorString(stream));
     return stream;
   }
 
-	return derToPem(ArrayToString(stream));
+  return derToPem(ArrayToString(stream));
 }
 
 function exportP12FileToPEM(file, passphrase = "root") {
-    var p12File = fs.readFileSync(file, "binary");
-	return ConvertP12ToPEM(p12File, passphrase);
+  var p12File = fs.readFileSync(file, "binary");
+  return ConvertP12ToPEM(p12File, passphrase);
 }
 
 // Exposed API

--- a/index.js
+++ b/index.js
@@ -22,6 +22,14 @@ function ArrayToString(array) {
   return out;
 }
 
+function reportIfError(obj, ret) {
+  // https://www.ibm.com/docs/en/zos/2.5.0?topic=reference-gsk-strerror
+  if (typeof ret !== "number" || ret === 0 || ret === 0x134CC000)
+    return false;
+  console.error("Error: " + obj.getErrorString(ret));
+  return true;
+}
+
 function derToPem(der) {
   var asnObj = forge.asn1.fromDer(der);
   var asn1Cert = forge.pki.certificateFromAsn1(asnObj);
@@ -91,31 +99,36 @@ function ConvertP12ToPKCS8(string, passphrase) {
 
 function exportKeysToPKCS8(obj, label, passphrase = "root") {
   var p12File = obj.exportKeyToBuffer(passphrase, label);
+  if (reportIfError(obj, p12File))
+    return p12File;
   return ConvertP12ToPKCS8(ArrayToString(p12File), passphrase);
 }
 
 function exportPublicKey(obj, label, passphrase = "root") {
   var p12File = obj.exportKeyToBuffer(passphrase, label);
+  if (reportIfError(obj, p12File))
+    return p12File;
   return ConvertP12ToPublicKey(ArrayToString(p12File), passphrase);
 }
 
 function exportKeysToPKCS1(obj, label, passphrase = "root") {
   var p12File = obj.exportKeyToBuffer(passphrase, label);
+  if (reportIfError(obj, p12File))
+    return p12File;
   return ConvertP12ToPKCS1(ArrayToString(p12File), passphrase);
 }
 
 function exportCertToPEM(obj, label) {
   var stream = obj.exportCertToBuffer(label);
-  if (typeof stream == "number" && stream != 0) {
-    console.log("Error: " + obj.getErrorString(stream));
+  if (reportIfError(obj, stream))
     return stream;
-  }
-
   return derToPem(ArrayToString(stream));
 }
 
 function exportP12FileToPEM(file, passphrase = "root") {
   var p12File = fs.readFileSync(file, "binary");
+  if (reportIfError(obj, p12File))
+    return p12File;
   return ConvertP12ToPEM(p12File, passphrase);
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1067 @@
+{
+  "name": "zcrypto",
+  "version": "1.4.2",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "zcrypto",
+      "version": "1.4.2",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "node-addon-api": "^1.6.3",
+        "node-forge": "^1.2.1",
+        "tmp": "^0.2.4",
+        "yargs-parser": "^20.2.7"
+      },
+      "devDependencies": {
+        "async": "^1.5.0",
+        "chai": "^4.1.2",
+        "mocha": "^9.2.1"
+      }
+    },
+    "node_modules/@ungap/promise-all-settled": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+      "dev": true
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==",
+      "dev": true
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
+      "integrity": "sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
+    },
+    "node_modules/debug": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/debug/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/escalade": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.x"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
+      "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
+      "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
+      "dev": true,
+      "dependencies": {
+        "@ungap/promise-all-settled": "1.1.2",
+        "ansi-colors": "4.1.1",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.5.3",
+        "debug": "4.3.3",
+        "diff": "5.0.0",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "7.2.0",
+        "growl": "1.10.5",
+        "he": "1.2.0",
+        "js-yaml": "4.1.0",
+        "log-symbols": "4.1.0",
+        "minimatch": "4.2.1",
+        "ms": "2.1.3",
+        "nanoid": "3.3.1",
+        "serialize-javascript": "6.0.0",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "8.1.1",
+        "which": "2.0.2",
+        "workerpool": "6.2.0",
+        "yargs": "16.2.0",
+        "yargs-parser": "20.2.4",
+        "yargs-unparser": "2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mochajs"
+      }
+    },
+    "node_modules/mocha/node_modules/yargs-parser": {
+      "version": "20.2.4",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
+      "dev": true,
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
+      "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg=="
+    },
+    "node_modules/node-forge": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+      "dev": true,
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.4.tgz",
+      "integrity": "sha512-UdiSoX6ypifLmrfQ/XfiawN6hkjSBpCjhKxxZcWlUUmoXLaCKQU0bx4HF/tdDK2uzRuchf1txGvrWBzYREssoQ==",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/workerpool": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
+      "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "node-addon-api": "^1.6.3",
     "node-forge": "^1.2.1",
-    "tmp": "^0.1.0",
+    "tmp": "^0.2.4",
     "yargs-parser": "^20.2.7"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zcrypto",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "A z/OS RACF keyring/kdb crypto npm for z/OS",
   "main": "index.js",
   "scripts": {

--- a/zcrypto_impl.cc
+++ b/zcrypto_impl.cc
@@ -13,225 +13,225 @@
 extern "C" int __chgfdccsid(int fd, unsigned short ccsid);
 
 extern "C" int createKDB_impl( const char* filename, const char* password, int length, int expiration, gsk_handle* handle) {
-    char * filename_e = (char*)malloc(strlen(filename) + 1);
-    memcpy(filename_e, filename, strlen(filename) + 1);
-    __a2e_l(filename_e, strlen(filename_e) + 1);
-    char * password_e = (char*)malloc(strlen(password) + 1);
-    memcpy(password_e, password, strlen(password) + 1);
-    __a2e_l(password_e, strlen(password_e) + 1);
+  char * filename_e = (char*)malloc(strlen(filename) + 1);
+  memcpy(filename_e, filename, strlen(filename) + 1);
+  __a2e_l(filename_e, strlen(filename_e) + 1);
+  char * password_e = (char*)malloc(strlen(password) + 1);
+  memcpy(password_e, password, strlen(password) + 1);
+  __a2e_l(password_e, strlen(password_e) + 1);
 
-    int orig = __ae_thread_swapmode(__AE_EBCDIC_MODE);
-    int rc = gsk_create_database ( filename_e, password_e, gskdb_dbtype_key, length, expiration, handle);
-    __ae_thread_swapmode(orig);
+  int orig = __ae_thread_swapmode(__AE_EBCDIC_MODE);
+  int rc = gsk_create_database ( filename_e, password_e, gskdb_dbtype_key, length, expiration, handle);
+  __ae_thread_swapmode(orig);
 
-    free(filename_e);
-    free(password_e);
-    return rc;
+  free(filename_e);
+  free(password_e);
+  return rc;
 }
 
 extern "C" int openKDB_impl( const char* filename, const char* password, gsk_handle* handle) {
-    char * filename_e = (char*)malloc(strlen(filename) + 1);
-    memcpy(filename_e, filename, strlen(filename) + 1);
-    __a2e_l(filename_e, strlen(filename_e) + 1);
-    char * password_e = (char*)malloc(strlen(password) + 1);
-    memcpy(password_e, password, strlen(password) + 1);
-    __a2e_l(password_e, strlen(password_e) + 1);
-    int num_records;
-    gskdb_database_type type;
+  char * filename_e = (char*)malloc(strlen(filename) + 1);
+  memcpy(filename_e, filename, strlen(filename) + 1);
+  __a2e_l(filename_e, strlen(filename_e) + 1);
+  char * password_e = (char*)malloc(strlen(password) + 1);
+  memcpy(password_e, password, strlen(password) + 1);
+  __a2e_l(password_e, strlen(password_e) + 1);
+  int num_records;
+  gskdb_database_type type;
 
-    int orig = __ae_thread_swapmode(__AE_EBCDIC_MODE);
-    int rc = gsk_open_database( filename_e, password_e, 1, handle, &type, &num_records);
-    __ae_thread_swapmode(orig);
+  int orig = __ae_thread_swapmode(__AE_EBCDIC_MODE);
+  int rc = gsk_open_database( filename_e, password_e, 1, handle, &type, &num_records);
+  __ae_thread_swapmode(orig);
 
-    free(filename_e);
-    free(password_e);
-    return rc;
+  free(filename_e);
+  free(password_e);
+  return rc;
 }
 
 extern "C" int closeKDB_impl( gsk_handle* handle) {
-    if (handle == nullptr || *handle == nullptr)
-        return 0;
-    int orig = __ae_thread_swapmode(__AE_EBCDIC_MODE);
-    int rc = gsk_close_database( handle );
-    __ae_thread_swapmode(orig);
-    return rc;
+  if (handle == nullptr || *handle == nullptr)
+    return 0;
+  int orig = __ae_thread_swapmode(__AE_EBCDIC_MODE);
+  int rc = gsk_close_database( handle );
+  __ae_thread_swapmode(orig);
+  return rc;
 }
 
 extern "C" char* errorString_impl( int err, char *errstr, int errstrlen ) {
-    int orig = __ae_thread_swapmode(__AE_EBCDIC_MODE);
-    const char* errstr_e  = gsk_strerror( err );
-    __ae_thread_swapmode(orig);
-    strncpy(errstr, errstr_e, errstrlen);
-    __e2a_l(errstr, errstrlen);
-    return errstr;
+  int orig = __ae_thread_swapmode(__AE_EBCDIC_MODE);
+  const char* errstr_e  = gsk_strerror( err );
+  __ae_thread_swapmode(orig);
+  strncpy(errstr, errstr_e, errstrlen);
+  __e2a_l(errstr, errstrlen);
+  return errstr;
 }
 
 extern "C" int openKeyRing_impl( const char* ring_name, gsk_handle* handle) {
-    char * ring_name_e = (char*)malloc(strlen(ring_name) + 1);
-    memcpy(ring_name_e, ring_name, strlen(ring_name) + 1);
-    __a2e_l(ring_name_e, strlen(ring_name_e) + 1);
-    int num_records;
-    int orig = __ae_thread_swapmode(__AE_EBCDIC_MODE);
-    int rc = gsk_open_keyring( ring_name_e, handle, &num_records);
-    free(ring_name_e);
-    __ae_thread_swapmode(orig);
-    return rc;
+  char * ring_name_e = (char*)malloc(strlen(ring_name) + 1);
+  memcpy(ring_name_e, ring_name, strlen(ring_name) + 1);
+  __a2e_l(ring_name_e, strlen(ring_name_e) + 1);
+  int num_records;
+  int orig = __ae_thread_swapmode(__AE_EBCDIC_MODE);
+  int rc = gsk_open_keyring( ring_name_e, handle, &num_records);
+  free(ring_name_e);
+  __ae_thread_swapmode(orig);
+  return rc;
 }
 
 extern "C" int exportKeyToFile_impl(const char* filename, const char* password, const char* label, gsk_handle* handle) {
-    char * password_e = (char*)malloc(strlen(password) + 1);
-    memcpy(password_e, password, strlen(password) + 1);
-    __a2e_l(password_e, strlen(password_e) + 1);
+  char * password_e = (char*)malloc(strlen(password) + 1);
+  memcpy(password_e, password, strlen(password) + 1);
+  __a2e_l(password_e, strlen(password_e) + 1);
 
-    char * label_e = (char*)malloc(strlen(label) + 1);
-    memcpy(label_e, label, strlen(label) + 1);
-    __a2e_l(label_e, strlen(label_e) + 1);
+  char * label_e = (char*)malloc(strlen(label) + 1);
+  memcpy(label_e, label, strlen(label) + 1);
+  __a2e_l(label_e, strlen(label_e) + 1);
 
-    gsk_buffer stream = {0, 0};
-    int rc = gsk_export_key(*handle, label_e, gskdb_export_pkcs12v3_binary,
-                            x509_alg_pbeWithSha1And3DesCbc, password_e,
-                            &stream);
+  gsk_buffer stream = {0, 0};
+  int rc = gsk_export_key(*handle, label_e, gskdb_export_pkcs12v3_binary,
+                          x509_alg_pbeWithSha1And3DesCbc, password_e,
+                          &stream);
 
-    free(password_e);
-    free(label_e);
-    if (rc !=0 ) {
-      gsk_free_buffer(&stream);
-      return rc;
-    }
-    FILE *fileptr;
-    fileptr = fopen(filename, "wb");  // Open the file in binary mode
-    write(fileno(fileptr), stream.data, stream.length);
+  free(password_e);
+  free(label_e);
+  if (rc !=0 ) {
     gsk_free_buffer(&stream);
-    fclose(fileptr); // Close the file
-    fileptr = fopen(filename, "a+");  // Open the file in binary mode
-    __chgfdccsid(fileno(fileptr), FT_BINARY);
-    fclose(fileptr); // Close the file
     return rc;
+  }
+  FILE *fileptr;
+  fileptr = fopen(filename, "wb");  // Open the file in binary mode
+  write(fileno(fileptr), stream.data, stream.length);
+  gsk_free_buffer(&stream);
+  fclose(fileptr); // Close the file
+  fileptr = fopen(filename, "a+");  // Open the file in binary mode
+  __chgfdccsid(fileno(fileptr), FT_BINARY);
+  fclose(fileptr); // Close the file
+  return rc;
 }
 
 extern "C" int exportCertToFile_impl(const char* filename, const char* label, gsk_handle* handle) {
-    char * label_e = (char*)malloc(strlen(label) + 1);
-    memcpy(label_e, label, strlen(label) + 1);
-    __a2e_l(label_e, strlen(label_e) + 1);
+  char * label_e = (char*)malloc(strlen(label) + 1);
+  memcpy(label_e, label, strlen(label) + 1);
+  __a2e_l(label_e, strlen(label_e) + 1);
 
-    gsk_buffer stream = {0, 0};
-    int rc = gsk_export_certificate(*handle, label_e, gskdb_export_der_binary, &stream);
-    free(label_e);
-    if (rc !=0 ) {
-      gsk_free_buffer(&stream);
-      return rc;
-    }
-
-    FILE *fileptr;
-    fileptr = fopen(filename, "wb");  // Open the file in binary mode
-    write(fileno(fileptr), stream.data, stream.length);
+  gsk_buffer stream = {0, 0};
+  int rc = gsk_export_certificate(*handle, label_e, gskdb_export_der_binary, &stream);
+  free(label_e);
+  if (rc !=0 ) {
     gsk_free_buffer(&stream);
-    fclose(fileptr); // Close the file
-    fileptr = fopen(filename, "a+");  // Open the file in binary mode
-    __chgfdccsid(fileno(fileptr), FT_BINARY);
-    fclose(fileptr); // Close the file
     return rc;
+  }
+
+  FILE *fileptr;
+  fileptr = fopen(filename, "wb");  // Open the file in binary mode
+  write(fileno(fileptr), stream.data, stream.length);
+  gsk_free_buffer(&stream);
+  fclose(fileptr); // Close the file
+  fileptr = fopen(filename, "a+");  // Open the file in binary mode
+  __chgfdccsid(fileno(fileptr), FT_BINARY);
+  fclose(fileptr); // Close the file
+  return rc;
 }
 
 extern "C" int exportCertToBuffer_impl(const char* label, gsk_buffer* stream, gsk_handle* handle) {
-    char * label_e = (char*)malloc(strlen(label) + 1);
-    memcpy(label_e, label, strlen(label) + 1);
-    __a2e_l(label_e, strlen(label_e) + 1);
+  char * label_e = (char*)malloc(strlen(label) + 1);
+  memcpy(label_e, label, strlen(label) + 1);
+  __a2e_l(label_e, strlen(label_e) + 1);
 
-    int rc = gsk_export_certificate(*handle, label_e, gskdb_export_der_binary, stream);
-    free(label_e);
-    return rc;
+  int rc = gsk_export_certificate(*handle, label_e, gskdb_export_der_binary, stream);
+  free(label_e);
+  return rc;
 }
 
 extern "C" int exportKeyToBuffer_impl(const char* password, const char* label, gsk_buffer* stream, gsk_handle* handle) {
-    char * password_e = (char*)malloc(strlen(password) + 1);
-    memcpy(password_e, password, strlen(password) + 1);
-    __a2e_l(password_e, strlen(password_e) + 1);
+  char * password_e = (char*)malloc(strlen(password) + 1);
+  memcpy(password_e, password, strlen(password) + 1);
+  __a2e_l(password_e, strlen(password_e) + 1);
 
-    char * label_e = (char*)malloc(strlen(label) + 1);
-    memcpy(label_e, label, strlen(label) + 1);
-    __a2e_l(label_e, strlen(label_e) + 1);
+  char * label_e = (char*)malloc(strlen(label) + 1);
+  memcpy(label_e, label, strlen(label) + 1);
+  __a2e_l(label_e, strlen(label_e) + 1);
 
-    int rc = gsk_export_key(*handle, label_e, gskdb_export_pkcs12v3_binary,
-                            x509_alg_pbeWithSha1And3DesCbc, password_e, stream);
-    free(password_e);
-    free(label_e);
-    return rc;
+  int rc = gsk_export_key(*handle, label_e, gskdb_export_pkcs12v3_binary,
+                          x509_alg_pbeWithSha1And3DesCbc, password_e, stream);
+  free(password_e);
+  free(label_e);
+  return rc;
 }
 
 extern "C" int importKey_impl(const char* filename, const char* password, const char* label, gsk_handle* handle) {
-    FILE *fileptr;
-    char * buffer;
-    long filelen;
+  FILE *fileptr;
+  char * buffer;
+  long filelen;
 
-    char * filename_e = (char*)malloc(strlen(filename) + 1);
-    memcpy(filename_e, filename, strlen(filename) + 1);
-    __a2e_l(filename_e, strlen(filename_e) + 1);
+  char * filename_e = (char*)malloc(strlen(filename) + 1);
+  memcpy(filename_e, filename, strlen(filename) + 1);
+  __a2e_l(filename_e, strlen(filename_e) + 1);
 
-    char * password_e = (char*)malloc(strlen(password) + 1);
-    memcpy(password_e, password, strlen(password) + 1);
-    __a2e_l(password_e, strlen(password_e) + 1);
+  char * password_e = (char*)malloc(strlen(password) + 1);
+  memcpy(password_e, password, strlen(password) + 1);
+  __a2e_l(password_e, strlen(password_e) + 1);
 
-    char * label_e = (char*)malloc(strlen(label) + 1);
-    memcpy(label_e, label, strlen(label) + 1);
-    __a2e_l(label_e, strlen(label_e) + 1);
+  char * label_e = (char*)malloc(strlen(label) + 1);
+  memcpy(label_e, label, strlen(label) + 1);
+  __a2e_l(label_e, strlen(label_e) + 1);
 
-    fileptr = fopen(filename, "rb");  // Open the file in binary mode
-    fseek(fileptr, 0, SEEK_END);      // Jump to the end of the file
-    filelen = ftell(fileptr);         // Get the current byte offset in the file
-    rewind(fileptr);                  // Jump back to the beginning of the file
+  fileptr = fopen(filename, "rb");  // Open the file in binary mode
+  fseek(fileptr, 0, SEEK_END);      // Jump to the end of the file
+  filelen = ftell(fileptr);         // Get the current byte offset in the file
+  rewind(fileptr);                  // Jump back to the beginning of the file
 
-    buffer = (char *)malloc((filelen+1)*sizeof(char)); // Enough memory for file + \0
-    fread(buffer, filelen, 1, fileptr); // Read in the entire file
-    fclose(fileptr); // Close the file
+  buffer = (char *)malloc((filelen+1)*sizeof(char)); // Enough memory for file + \0
+  fread(buffer, filelen, 1, fileptr); // Read in the entire file
+  fclose(fileptr); // Close the file
 
-    gsk_buffer stream = {(unsigned int)((filelen+1)*sizeof(char)), (void*)buffer};
+  gsk_buffer stream = {(unsigned int)((filelen+1)*sizeof(char)), (void*)buffer};
 
-    int rc = gsk_import_key(*handle, label_e, password_e, &stream);
+  int rc = gsk_import_key(*handle, label_e, password_e, &stream);
 
-    free(filename_e);
-    free(password_e);
-    free(label_e);
-    free(buffer);
-    if (stream.data != buffer)
-      gsk_free_buffer(&stream);
-    return rc;
+  free(filename_e);
+  free(password_e);
+  free(label_e);
+  free(buffer);
+  if (stream.data != buffer)
+    gsk_free_buffer(&stream);
+  return rc;
 }
 
 // The supplied stream can represent either the ASN.1 DER encoding for the certificate or the Cryptographic Message Syntax (PKCS #7)
 int importCertificate(char* filename, char* label, gsk_handle* handle) {
-    FILE *fileptr;
-    char *buffer;
-    long filelen;
+  FILE *fileptr;
+  char *buffer;
+  long filelen;
 
-    fileptr = fopen(filename, "rb");  // Open the file in binary mode
-    fseek(fileptr, 0, SEEK_END);      // Jump to the end of the file
-    filelen = ftell(fileptr);         // Get the current byte offset in the file
-    rewind(fileptr);                  // Jump back to the beginning of the file
+  fileptr = fopen(filename, "rb");  // Open the file in binary mode
+  fseek(fileptr, 0, SEEK_END);      // Jump to the end of the file
+  filelen = ftell(fileptr);         // Get the current byte offset in the file
+  rewind(fileptr);                  // Jump back to the beginning of the file
 
-    buffer = (char *)malloc((filelen+1)*sizeof(char)); // Enough memory for file + \0
-    fread(buffer, filelen, 1, fileptr); // Read in the entire file
-    fclose(fileptr); // Close the file
+  buffer = (char *)malloc((filelen+1)*sizeof(char)); // Enough memory for file + \0
+  fread(buffer, filelen, 1, fileptr); // Read in the entire file
+  fclose(fileptr); // Close the file
 
-    gsk_buffer stream = {(unsigned int)((filelen+1)*sizeof(char)), (void*)buffer};
+  gsk_buffer stream = {(unsigned int)((filelen+1)*sizeof(char)), (void*)buffer};
 
-    int rc = gsk_import_certificate(*handle, label, &stream);
-    free(buffer);
-    if (stream.data != buffer)
-      gsk_free_buffer(&stream);
-    return rc;
+  int rc = gsk_import_certificate(*handle, label, &stream);
+  free(buffer);
+  if (stream.data != buffer)
+    gsk_free_buffer(&stream);
+  return rc;
 }
 
 // The supplied stream can represent either the ASN.1 DER encoding for the certificate or the Cryptographic Message Syntax (PKCS #7)
 int exportCertificate(char* filename, char* label, gsk_handle* handle) {
-    gsk_buffer stream = {0, 0};
+  gsk_buffer stream = {0, 0};
 
-    int rc = gsk_export_certificate (*handle, label, gskdb_export_der_binary, &stream);
+  int rc = gsk_export_certificate (*handle, label, gskdb_export_der_binary, &stream);
 
-    FILE *fileptr;
-    fileptr = fopen(filename, "wb");  // Open the file in binary mode
-    fwrite(stream.data, stream.length, 1, fileptr);
-    gsk_free_buffer(&stream);
-    fclose(fileptr); // Close the file
-    return rc;
+  FILE *fileptr;
+  fileptr = fopen(filename, "wb");  // Open the file in binary mode
+  fwrite(stream.data, stream.length, 1, fileptr);
+  gsk_free_buffer(&stream);
+  fclose(fileptr); // Close the file
+  return rc;
 }


### PR DESCRIPTION
- check and log errors (to stderr) from the exposed `export*` APIs.
- update tmp version to ^0.2.4 & add package-lock.json to resolve security vulnerability: tmp@0.2.3 is vulnerable to an Arbitrary temporary file / directory write via symbolic link dir parameter.
- update node-zcrypto version to 1.4.2.
- remove tabs & adjust indentation