### PR TITLE
add missing switch to EBCDIC mode before gsk_ API calls + add optional debug statements

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -15,7 +15,9 @@
             ],
           }],
           [ "NODE_VERSION < 16", {
-            "cflags": [  "-qascii" ]
+            "cflags": [  "-qascii" ],
+          },{
+            "cflags": [  "-Wno-unknown-pragmas", "-Wno-trigraphs" ]
           }],
         ],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zcrypto",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zcrypto",
-      "version": "1.4.3",
+      "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "node-addon-api": "^8.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,23 @@
 {
   "name": "zcrypto",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zcrypto",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "node-addon-api": "^1.6.3",
-        "node-forge": "^1.2.1",
-        "tmp": "^0.2.4",
-        "yargs-parser": "^20.2.7"
+        "node-addon-api": "^8.7.0",
+        "node-forge": "^1.4.0",
+        "tmp": "^0.2.5",
+        "yargs-parser": "^20.2.9"
       },
       "devDependencies": {
-        "async": "^1.5.0",
-        "chai": "^4.1.2",
-        "mocha": "^11.7.1"
+        "async": "^1.5.2",
+        "chai": "^4.5.0",
+        "mocha": "^11.7.5"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -25,6 +25,7 @@
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
         "string-width-cjs": "npm:string-width@^4.2.0",
@@ -42,16 +43,18 @@
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -64,6 +67,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -78,13 +82,15 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -93,19 +99,22 @@
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -114,13 +123,15 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/camelcase": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -129,10 +140,11 @@
       }
     },
     "node_modules/chai": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
-      "integrity": "sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.3",
@@ -140,7 +152,7 @@
         "get-func-name": "^2.0.2",
         "loupe": "^2.3.6",
         "pathval": "^1.1.1",
-        "type-detect": "^4.0.8"
+        "type-detect": "^4.1.0"
       },
       "engines": {
         "node": ">=4"
@@ -151,6 +163,7 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -167,6 +180,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -179,6 +193,7 @@
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
       "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "get-func-name": "^2.0.2"
       },
@@ -191,6 +206,7 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -206,6 +222,7 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -220,6 +237,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -228,13 +246,15 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cliui/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -249,6 +269,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -261,6 +282,7 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -278,6 +300,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -289,13 +312,15 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -306,10 +331,11 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -327,6 +353,7 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
       "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -339,6 +366,7 @@
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
       "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "type-detect": "^4.0.0"
       },
@@ -351,6 +379,7 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
       "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }
@@ -359,19 +388,22 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -381,6 +413,7 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -393,6 +426,7 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -409,6 +443,7 @@
       "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
       "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "bin": {
         "flat": "cli.js"
       }
@@ -418,6 +453,7 @@
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
         "signal-exit": "^4.0.1"
@@ -434,6 +470,7 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -443,15 +480,18 @@
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
       "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -472,6 +512,7 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -481,6 +522,7 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "he": "bin/he"
       }
@@ -490,6 +532,17 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -499,6 +552,7 @@
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
       "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -508,6 +562,7 @@
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -519,13 +574,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -537,10 +594,11 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -553,6 +611,7 @@
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -568,6 +627,7 @@
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
       "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.0",
         "is-unicode-supported": "^0.1.0"
@@ -584,6 +644,7 @@
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
       "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "get-func-name": "^2.0.1"
       }
@@ -592,15 +653,17 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -610,19 +673,21 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mocha": {
-      "version": "11.7.1",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.1.tgz",
-      "integrity": "sha512-5EK+Cty6KheMS/YLPPMJC64g5V61gIR25KsRItHw6x4hEKT6Njp1n9LOlH4gpevuwMVS66SXaBBpg+RWZkza4A==",
+      "version": "11.7.5",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.5.tgz",
+      "integrity": "sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "browser-stdout": "^1.3.1",
         "chokidar": "^4.0.1",
@@ -632,6 +697,7 @@
         "find-up": "^5.0.0",
         "glob": "^10.4.5",
         "he": "^1.2.0",
+        "is-path-inside": "^3.0.3",
         "js-yaml": "^4.1.0",
         "log-symbols": "^4.1.0",
         "minimatch": "^9.0.5",
@@ -658,6 +724,7 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -666,17 +733,23 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/node-addon-api": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
-      "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg=="
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
+      "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
     },
     "node_modules/node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
       }
@@ -686,6 +759,7 @@
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -701,6 +775,7 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -715,13 +790,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true
+      "dev": true,
+      "license": "BlueOak-1.0.0"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -731,6 +808,7 @@
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -740,6 +818,7 @@
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -756,6 +835,7 @@
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
       "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -764,13 +844,15 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
@@ -780,6 +862,7 @@
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
       },
@@ -793,6 +876,7 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -815,13 +899,15 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/serialize-javascript": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
       "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "randombytes": "^2.1.0"
       }
@@ -831,6 +917,7 @@
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -843,6 +930,7 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -852,6 +940,7 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=14"
       },
@@ -864,6 +953,7 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -882,6 +972,7 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -896,6 +987,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -904,13 +996,15 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -919,12 +1013,13 @@
       }
     },
     "node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
@@ -939,6 +1034,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -951,6 +1047,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -960,6 +1057,7 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -972,6 +1070,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -983,18 +1082,20 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.4.tgz",
-      "integrity": "sha512-UdiSoX6ypifLmrfQ/XfiawN6hkjSBpCjhKxxZcWlUUmoXLaCKQU0bx4HF/tdDK2uzRuchf1txGvrWBzYREssoQ==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.14"
       }
     },
     "node_modules/type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -1004,6 +1105,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -1015,16 +1117,18 @@
       }
     },
     "node_modules/workerpool": {
-      "version": "9.3.3",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.3.tgz",
-      "integrity": "sha512-slxCaKbYjEdFT/o2rH9xS1hf4uRDch1w7Uo+apxhZ+sf/1d9e0ZVkn42kPNGP2dgjIx6YFvSevj0zHvbWe2jdw==",
-      "dev": true
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.4.tgz",
+      "integrity": "sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
@@ -1043,6 +1147,7 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -1060,6 +1165,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -1068,13 +1174,15 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/wrap-ansi-cjs/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -1089,6 +1197,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -1097,10 +1206,11 @@
       }
     },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -1113,6 +1223,7 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=10"
       }
@@ -1122,6 +1233,7 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -1139,6 +1251,7 @@
       "version": "20.2.9",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "license": "ISC",
       "engines": {
         "node": ">=10"
       }
@@ -1148,6 +1261,7 @@
       "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
       "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "camelcase": "^6.0.0",
         "decamelize": "^4.0.0",
@@ -1163,6 +1277,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -1171,13 +1286,15 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yargs/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -1192,6 +1309,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -1204,6 +1322,7 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -1213,6 +1332,7 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zcrypto",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "description": "A z/OS RACF keyring/kdb crypto npm for z/OS",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zcrypto",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "A z/OS RACF keyring/kdb crypto npm for z/OS",
   "main": "index.js",
   "scripts": {
@@ -18,15 +18,15 @@
     "RACF"
   ],
   "dependencies": {
-    "node-addon-api": "^1.6.3",
-    "node-forge": "^1.2.1",
-    "tmp": "^0.2.4",
-    "yargs-parser": "^20.2.7"
+    "node-addon-api": "^8.7.0",
+    "node-forge": "^1.4.0",
+    "tmp": "^0.2.5",
+    "yargs-parser": "^20.2.9"
   },
   "devDependencies": {
-    "async": "^1.5.0",
-    "chai": "^4.1.2",
-    "mocha": "^11.7.1"
+    "async": "^1.5.2",
+    "chai": "^4.5.0",
+    "mocha": "^11.7.5"
   },
   "author": "Igor Todorovski",
   "license": "Apache-2.0"

--- a/zcrypto.h
+++ b/zcrypto.h
@@ -4,6 +4,10 @@
  * US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
  */
 
+#if !defined(__MVS__)
+#error This addon is for zos only
+#endif
+
 #ifndef __ZCRYPTO_H_
 #define __ZCRYPTO_H_ 1
 
@@ -48,8 +52,13 @@ class ZCrypto : public Napi::ObjectWrap<ZCrypto> {
 };
 
 
-#if !defined(__MVS__)
-#error This addon is for zos only
+#ifdef DEBUG
+char* getErrStr(int rc);
+void dbgPrintf(const char *fname, int linenum, const char *funcname,
+               const char *format, ...);
+#define DPRINTF(...) dbgPrintf(__FILE__, __LINE__, __FUNCTION__, __VA_ARGS__);
+#else
+#define DPRINTF(...) (void)0
 #endif
 
 #endif

--- a/zcrypto_impl.cc
+++ b/zcrypto_impl.cc
@@ -215,7 +215,15 @@ int importCertificate(char* filename, char* label, gsk_handle* handle) {
 
   gsk_buffer stream = {(unsigned int)((filelen+1)*sizeof(char)), (void*)buffer};
 
-  int rc = gsk_import_certificate(*handle, label, &stream);
+  char *label_e = (char*)malloc(strlen(label) + 1);
+  memcpy(label_e, label, strlen(label) + 1);
+  __a2e_l(label_e, strlen(label_e) + 1);
+
+  int orig = __ae_thread_swapmode(__AE_EBCDIC_MODE);
+  int rc = gsk_import_certificate(*handle, label_e, &stream);
+  __ae_thread_swapmode(orig);
+  free(label_e);
+
   free(buffer);
   if (stream.data != buffer)
     gsk_free_buffer(&stream);
@@ -226,7 +234,14 @@ int importCertificate(char* filename, char* label, gsk_handle* handle) {
 int exportCertificate(char* filename, char* label, gsk_handle* handle) {
   gsk_buffer stream = {0, 0};
 
-  int rc = gsk_export_certificate (*handle, label, gskdb_export_der_binary, &stream);
+  char *label_e = (char*)malloc(strlen(label) + 1);
+  memcpy(label_e, label, strlen(label) + 1);
+  __a2e_l(label_e, strlen(label_e) + 1);
+
+  int orig = __ae_thread_swapmode(__AE_EBCDIC_MODE);
+  int rc = gsk_export_certificate (*handle, label_e, gskdb_export_der_binary, &stream);
+  __ae_thread_swapmode(orig);
+  free(label_e);
 
   FILE *fileptr;
   fileptr = fopen(filename, "wb");  // Open the file in binary mode

--- a/zcrypto_impl.cc
+++ b/zcrypto_impl.cc
@@ -8,6 +8,11 @@
 #include <_Nascii.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#ifdef DEBUG
+#include <mutex>
+#include <libgen.h>
+#include <stdarg.h>
+#endif
 
 
 extern "C" int __chgfdccsid(int fd, unsigned short ccsid);
@@ -23,6 +28,11 @@ extern "C" int createKDB_impl( const char* filename, const char* password, int l
   int orig = __ae_thread_swapmode(__AE_EBCDIC_MODE);
   int rc = gsk_create_database ( filename_e, password_e, gskdb_dbtype_key, length, expiration, handle);
   __ae_thread_swapmode(orig);
+
+  DPRINTF("%sgsk_create_database(filename=%s, gskdb_dbtype_key, len=%d, "
+          "exp=%d, handle=%p): rc=%d%s\n",
+          (rc == 0) ? "" : "ERROR ", filename, length, expiration, handle, rc,
+          getErrStr(rc));
 
   free(filename_e);
   free(password_e);
@@ -43,6 +53,11 @@ extern "C" int openKDB_impl( const char* filename, const char* password, gsk_han
   int rc = gsk_open_database( filename_e, password_e, 1, handle, &type, &num_records);
   __ae_thread_swapmode(orig);
 
+  DPRINTF("%sgsk_open_database(filename=%s, 1, handle=%p) type=%d, "
+          "num_records=%d, rc=%d%s\n",
+          (rc == 0) ? "" : "ERROR ", filename, handle, type, num_records, rc,
+          getErrStr(rc));
+
   free(filename_e);
   free(password_e);
   return rc;
@@ -54,6 +69,10 @@ extern "C" int closeKDB_impl( gsk_handle* handle) {
   int orig = __ae_thread_swapmode(__AE_EBCDIC_MODE);
   int rc = gsk_close_database( handle );
   __ae_thread_swapmode(orig);
+
+  DPRINTF("%sgsk_close_database(handle=%p): rc=%d%s\n",
+          (rc == 0) ? "" : "ERROR ", handle, rc, getErrStr(rc));
+
   return rc;
 }
 
@@ -75,6 +94,12 @@ extern "C" int openKeyRing_impl( const char* ring_name, gsk_handle* handle) {
   int rc = gsk_open_keyring( ring_name_e, handle, &num_records);
   free(ring_name_e);
   __ae_thread_swapmode(orig);
+
+  DPRINTF(
+      "%sgsk_open_keyring(*ringname=%s, handle=%p) num_records=%d: rc=%d%s\n",
+      (rc == 0) ? "" : "ERROR ", ring_name, handle, num_records, rc,
+      getErrStr(rc));
+
   return rc;
 }
 
@@ -94,19 +119,39 @@ extern "C" int exportKeyToFile_impl(const char* filename, const char* password, 
                           &stream);
   __ae_thread_swapmode(orig);
 
+  DPRINTF("%sgsk_export_key(handle=%p, label=%s, gskdb_export_pkcs12v3_binary, "
+          "x509_alg_pbeWithSha1And3DesCbc) stream={%u,%p}: rc=%d%s\n",
+          (rc == 0) ? "" : "ERROR ", handle, label, stream.length, stream.data,
+          rc, getErrStr(rc));
+
   free(password_e);
   free(label_e);
   if (rc !=0 ) {
     gsk_free_buffer(&stream);
     return rc;
   }
-  FILE *fileptr;
-  fileptr = fopen(filename, "wb");  // Open the file in binary mode
-  write(fileno(fileptr), stream.data, stream.length);
+  FILE *fileptr = fopen(filename, "wb");  // Open the file in binary mode
+
+  DPRINTF("%sfopen(%s, wb): errno=%d\n", (fileptr != NULL) ? "" : "ERROR ",
+          filename, errno);
+
+  rc = write(fileno(fileptr), stream.data, stream.length);
+  DPRINTF("%swrite(%s, data=%p, len=%d): rc=%d, errno=%d\n",
+          (rc == static_cast<int>(stream.length)) ? "" : "ERROR ", filename,
+          stream.data, stream.length, rc, errno);
+
   gsk_free_buffer(&stream);
   fclose(fileptr); // Close the file
   fileptr = fopen(filename, "a+");  // Open the file in binary mode
-  __chgfdccsid(fileno(fileptr), FT_BINARY);
+
+  DPRINTF("%sfopen(%s, a+): errno=%d\n", (fileptr != NULL) ? "" : "ERROR ",
+          filename, errno);
+
+  rc = __chgfdccsid(fileno(fileptr), FT_BINARY);
+
+  DPRINTF("%s__chgfdccsid(filename=%s, FT_BINARY): rc=%d, errno=%d\n",
+          (rc == 0) ? "" : "ERROR ", filename, rc, errno);
+
   fclose(fileptr); // Close the file
   return rc;
 }
@@ -121,18 +166,41 @@ extern "C" int exportCertToFile_impl(const char* filename, const char* label, gs
   int rc = gsk_export_certificate(*handle, label_e, gskdb_export_der_binary, &stream);
   __ae_thread_swapmode(orig);
   free(label_e);
+
+  DPRINTF(
+      "%sgsk_export_certificate(handle=%p, label=%s, gskdb_export_der_binary) "
+      "stream={%u,%p}: rc=%d%s\n",
+      (rc == 0) ? "" : "ERROR ", handle, label, stream.length, stream.data, rc,
+      getErrStr(rc));
+
   if (rc !=0 ) {
     gsk_free_buffer(&stream);
     return rc;
   }
 
-  FILE *fileptr;
-  fileptr = fopen(filename, "wb");  // Open the file in binary mode
-  write(fileno(fileptr), stream.data, stream.length);
+  FILE *fileptr = fopen(filename, "wb");  // Open the file in binary mode
+
+  DPRINTF("%sfopen(%s, wb): errno=%d\n", (fileptr != NULL) ? "" : "ERROR ",
+          filename, errno);
+
+  rc = write(fileno(fileptr), stream.data, stream.length);
+
+  DPRINTF("%swrite(%s, data=%p, len=%d): rc=%d, errno=%d\n",
+          (rc == static_cast<int>(stream.length)) ? "" : "ERROR ", filename,
+          stream.data, stream.length, rc, errno);
+
   gsk_free_buffer(&stream);
   fclose(fileptr); // Close the file
   fileptr = fopen(filename, "a+");  // Open the file in binary mode
-  __chgfdccsid(fileno(fileptr), FT_BINARY);
+
+  DPRINTF("%sfopen(%s, a+): errno=%d\n", (fileptr != NULL) ? "" : "ERROR ",
+          filename, errno);
+
+  rc = __chgfdccsid(fileno(fileptr), FT_BINARY);
+
+  DPRINTF("%s__chgfdccsid(filename=%s, FT_BINARY): rc=%d, errno=%d\n",
+          (rc == 0) ? "" : "ERROR ", filename, rc, errno);
+
   fclose(fileptr); // Close the file
   return rc;
 }
@@ -145,6 +213,13 @@ extern "C" int exportCertToBuffer_impl(const char* label, gsk_buffer* stream, gs
   int orig = __ae_thread_swapmode(__AE_EBCDIC_MODE);
   int rc = gsk_export_certificate(*handle, label_e, gskdb_export_der_binary, stream);
   __ae_thread_swapmode(orig);
+
+  DPRINTF(
+      "%sgsk_export_certificate(handle=%p, label=%s, gskdb_export_der_binary, "
+      "stream={%d, %p}): rc=%d%s\n",
+      (rc == 0) ? "" : "ERROR ", handle, label, stream->length, stream->data,
+      rc, getErrStr(rc));
+
   free(label_e);
   return rc;
 }
@@ -162,13 +237,18 @@ extern "C" int exportKeyToBuffer_impl(const char* password, const char* label, g
   int rc = gsk_export_key(*handle, label_e, gskdb_export_pkcs12v3_binary,
                           x509_alg_pbeWithSha1And3DesCbc, password_e, stream);
   __ae_thread_swapmode(orig);
+
+  DPRINTF("%sgsk_export_key(handle=%p, label=%s, gskdb_export_pkcs12v3_binary, "
+          "x509_alg_pbeWithSha1And3DesCbc, stream={%u,%p}): rc=%d%s\n",
+          (rc == 0) ? "" : "ERROR ", handle, label, stream->length,
+          stream->data, rc, getErrStr(rc));
+
   free(password_e);
   free(label_e);
   return rc;
 }
 
 extern "C" int importKey_impl(const char* filename, const char* password, const char* label, gsk_handle* handle) {
-  FILE *fileptr;
   char * buffer;
   long filelen;
 
@@ -184,43 +264,69 @@ extern "C" int importKey_impl(const char* filename, const char* password, const 
   memcpy(label_e, label, strlen(label) + 1);
   __a2e_l(label_e, strlen(label_e) + 1);
 
-  fileptr = fopen(filename, "rb");  // Open the file in binary mode
-  fseek(fileptr, 0, SEEK_END);      // Jump to the end of the file
+  FILE *fileptr = fopen(filename, "rb");  // Open the file in binary mode
+
+  DPRINTF("%sfopen(%s, rb): errno=%d\n", (fileptr != NULL) ? "" : "ERROR ",
+          filename, errno);
+
+  int rc = fseek(fileptr, 0, SEEK_END);      // Jump to the end of the file
+
+  DPRINTF("%sfseek(%s, 0, SEEK_END): rc=%d, errno=%d\n",
+          (rc == 0) ? "" : "ERROR ", filename, rc, errno);
+
   filelen = ftell(fileptr);         // Get the current byte offset in the file
   rewind(fileptr);                  // Jump back to the beginning of the file
 
   buffer = (char *)malloc((filelen+1)*sizeof(char)); // Enough memory for file + \0
-  fread(buffer, filelen, 1, fileptr); // Read in the entire file
+  rc = fread(buffer, filelen, 1, fileptr); // Read in the entire file
+
+  DPRINTF("%sfread(len=%d, 1, filenmae=%s): rc=%d, errno=%d\n",
+          (rc == 1) ? "" : "ERROR ", filelen, filename, rc, errno);
+
   fclose(fileptr); // Close the file
 
   gsk_buffer stream = {(unsigned int)((filelen+1)*sizeof(char)), (void*)buffer};
 
   int orig = __ae_thread_swapmode(__AE_EBCDIC_MODE);
-  int rc = gsk_import_key(*handle, label_e, password_e, &stream);
+  rc = gsk_import_key(*handle, label_e, password_e, &stream);
   __ae_thread_swapmode(orig);
+
+  DPRINTF("%sgsk_import_key(handle=%p, label=%s) stream={%u,%p}: rc=%d%s\n",
+          (rc == 0) ? "" : "ERROR ", handle, label, stream.length, stream.data,
+          rc, getErrStr(rc));
 
   free(filename_e);
   free(password_e);
   free(label_e);
   free(buffer);
-  if (stream.data != buffer)
+  if (stream.data != buffer) {
     gsk_free_buffer(&stream);
+    DPRINTF("NOTE: gsk_free_buffer due to %p != %p\n", stream.data, buffer);
+  }
   return rc;
 }
 
 // The supplied stream can represent either the ASN.1 DER encoding for the certificate or the Cryptographic Message Syntax (PKCS #7)
 int importCertificate(char* filename, char* label, gsk_handle* handle) {
-  FILE *fileptr;
-  char *buffer;
-  long filelen;
+  FILE *fileptr = fopen(filename, "rb");  // Open the file in binary mode
 
-  fileptr = fopen(filename, "rb");  // Open the file in binary mode
-  fseek(fileptr, 0, SEEK_END);      // Jump to the end of the file
-  filelen = ftell(fileptr);         // Get the current byte offset in the file
+  DPRINTF("%sfopen(%s, rb): errno=%d\n", (fileptr != NULL) ? "" : "ERROR ",
+          filename, errno);
+
+  int rc = fseek(fileptr, 0, SEEK_END);      // Jump to the end of the file
+
+  DPRINTF("%sfseek(%s, 0, SEEK_END): rc=%d, errno=%d\n",
+          (rc == 0) ? "" : "ERROR ", filename, rc, errno);
+
+  int filelen = ftell(fileptr);         // Get the current byte offset in the file
   rewind(fileptr);                  // Jump back to the beginning of the file
 
-  buffer = (char *)malloc((filelen+1)*sizeof(char)); // Enough memory for file + \0
-  fread(buffer, filelen, 1, fileptr); // Read in the entire file
+  char *buffer = (char *)malloc((filelen+1)*sizeof(char)); // Enough memory for file + \0
+  rc = fread(buffer, filelen, 1, fileptr); // Read in the entire file
+
+  DPRINTF("%sfread(len=%d, 1, filenmae=%s: rc=%d, errno=%d\n",
+          (rc == 1) ? "" : "ERROR ", filelen, filename, rc, errno);
+
   fclose(fileptr); // Close the file
 
   gsk_buffer stream = {(unsigned int)((filelen+1)*sizeof(char)), (void*)buffer};
@@ -230,13 +336,20 @@ int importCertificate(char* filename, char* label, gsk_handle* handle) {
   __a2e_l(label_e, strlen(label_e) + 1);
 
   int orig = __ae_thread_swapmode(__AE_EBCDIC_MODE);
-  int rc = gsk_import_certificate(*handle, label_e, &stream);
+  rc = gsk_import_certificate(*handle, label_e, &stream);
   __ae_thread_swapmode(orig);
   free(label_e);
 
+  DPRINTF("%sgsk_import_certificate(handle=%p, label=%s) stream={%u,%p}): "
+          "rc=%d%s\n",
+          (rc == 0) ? "" : "ERROR ", handle, label, stream.length, stream.data,
+          rc, getErrStr(rc));
+
   free(buffer);
-  if (stream.data != buffer)
+  if (stream.data != buffer) {
     gsk_free_buffer(&stream);
+    DPRINTF("NOTE: gsk_free_buffer due to %p != %p\n", stream.data, buffer);
+  }
   return rc;
 }
 
@@ -253,10 +366,77 @@ int exportCertificate(char* filename, char* label, gsk_handle* handle) {
   __ae_thread_swapmode(orig);
   free(label_e);
 
-  FILE *fileptr;
-  fileptr = fopen(filename, "wb");  // Open the file in binary mode
-  fwrite(stream.data, stream.length, 1, fileptr);
+  DPRINTF("%sgsk_export_certificate(handle=%p, label=%s, "
+          "gskdb_export_der_binary) stream={%d, %p}: rc=%d%s\n",
+          (rc == 0) ? "" : "ERROR ", handle, label, stream.length, stream.data,
+          rc, getErrStr(rc));
+
+  FILE *fileptr = fopen(filename, "wb");  // Open the file in binary mode
+
+  DPRINTF("%sfopen(%s, wb) errno=%d\n", (fileptr != NULL) ? "" : "ERROR ",
+          filename, errno);
+
+  rc = fwrite(stream.data, stream.length, 1, fileptr);
+
+  DPRINTF("%sfwrite(data=%p, len=%d, 1, %s): rc=%d, errno=%d\n",
+          (rc == 0) ? "" : "ERROR ", stream.data, stream.length, filename, rc,
+          errno);
+
   gsk_free_buffer(&stream);
   fclose(fileptr); // Close the file
   return rc;
 }
+
+
+#ifdef DEBUG
+char* getErrStr(int rc) {
+  // This is called for rc from gsk_ APIs only.
+  static std::mutex mtx;
+  std::lock_guard<std::mutex> lock(mtx);
+  static char errstr[256];
+  if (rc == 0) {
+    *errstr = 0;
+  } else {
+    int orig = __ae_thread_swapmode(__AE_EBCDIC_MODE);
+    const char* errstr_e  = gsk_strerror(rc);
+    __ae_thread_swapmode(orig);
+    char rcstr[256];
+    strncpy(rcstr, errstr_e, sizeof(rcstr));
+    __e2a_l(rcstr, sizeof(rcstr));
+    snprintf(errstr, sizeof(errstr), " (%s) ", rcstr);
+  }
+  return errstr;
+}
+
+void dbgPrintf(const char *fname, int linenum, const char *funcname,
+               const char *format, ...) {
+  static std::mutex mtx;
+  std::lock_guard<std::mutex> lock(mtx);
+  static const char *logfname = getenv("ZCRYPTO_LOGFILE");
+  if (!logfname)
+    return;
+
+  va_list args;
+  va_start(args, format);
+  static bool isstderr = !strcmp(logfname, "stderr");
+  static bool isstdout = !strcmp(logfname, "stdout");
+  static FILE *fp = NULL;
+  static bool binit = false;
+  if (binit && fp == NULL)
+    return;
+
+  fp = isstderr ? stderr : isstdout ? stdout : fopen(logfname, "a+");
+
+  if (fp == NULL) {
+    va_end(args);
+    perror(logfname);
+    binit = true;
+    return;
+  }
+  fprintf(fp, "In %s:%d:%s ", fname, linenum, funcname);
+  vfprintf(fp, format, args);
+  va_end(args);
+  if (fp != stderr)
+    fflush(fp);
+}
+#endif

--- a/zcrypto_impl.cc
+++ b/zcrypto_impl.cc
@@ -88,9 +88,11 @@ extern "C" int exportKeyToFile_impl(const char* filename, const char* password, 
   __a2e_l(label_e, strlen(label_e) + 1);
 
   gsk_buffer stream = {0, 0};
+  int orig = __ae_thread_swapmode(__AE_EBCDIC_MODE);
   int rc = gsk_export_key(*handle, label_e, gskdb_export_pkcs12v3_binary,
                           x509_alg_pbeWithSha1And3DesCbc, password_e,
                           &stream);
+  __ae_thread_swapmode(orig);
 
   free(password_e);
   free(label_e);
@@ -115,7 +117,9 @@ extern "C" int exportCertToFile_impl(const char* filename, const char* label, gs
   __a2e_l(label_e, strlen(label_e) + 1);
 
   gsk_buffer stream = {0, 0};
+  int orig = __ae_thread_swapmode(__AE_EBCDIC_MODE);
   int rc = gsk_export_certificate(*handle, label_e, gskdb_export_der_binary, &stream);
+  __ae_thread_swapmode(orig);
   free(label_e);
   if (rc !=0 ) {
     gsk_free_buffer(&stream);
@@ -138,7 +142,9 @@ extern "C" int exportCertToBuffer_impl(const char* label, gsk_buffer* stream, gs
   memcpy(label_e, label, strlen(label) + 1);
   __a2e_l(label_e, strlen(label_e) + 1);
 
+  int orig = __ae_thread_swapmode(__AE_EBCDIC_MODE);
   int rc = gsk_export_certificate(*handle, label_e, gskdb_export_der_binary, stream);
+  __ae_thread_swapmode(orig);
   free(label_e);
   return rc;
 }
@@ -152,8 +158,10 @@ extern "C" int exportKeyToBuffer_impl(const char* password, const char* label, g
   memcpy(label_e, label, strlen(label) + 1);
   __a2e_l(label_e, strlen(label_e) + 1);
 
+  int orig = __ae_thread_swapmode(__AE_EBCDIC_MODE);
   int rc = gsk_export_key(*handle, label_e, gskdb_export_pkcs12v3_binary,
                           x509_alg_pbeWithSha1And3DesCbc, password_e, stream);
+  __ae_thread_swapmode(orig);
   free(password_e);
   free(label_e);
   return rc;
@@ -187,7 +195,9 @@ extern "C" int importKey_impl(const char* filename, const char* password, const 
 
   gsk_buffer stream = {(unsigned int)((filelen+1)*sizeof(char)), (void*)buffer};
 
+  int orig = __ae_thread_swapmode(__AE_EBCDIC_MODE);
   int rc = gsk_import_key(*handle, label_e, password_e, &stream);
+  __ae_thread_swapmode(orig);
 
   free(filename_e);
   free(password_e);


### PR DESCRIPTION
- Fix bug in which some calls to gsk_ APIs weren't made in EBCDIC mode
- Pass the label argument to gsk_ APIs as EBCDIC in import/export cert zcrypto_impl functions
- Update npm dependencies to resolve a compiler error from node-addon-api with at least Node.js v24, and change zcrypto version to v1.5.0
- Add debug info to the zcrypto_impl functions. To enable the added debug statements, install as follows:
`CFLAGS='-DDEBUG' CXXFLAGS=$CFLAGS npm install`
and run with environment variable `ZCRYPTO_LOGFILE` set to one of:
`stdout`, `stderr`, or a file name - where the debug messages will be written.
Example:
`ZCRYPTO_LOGFILE=/tmp/z.log npm test`
- remove known and harmless compiler warnings to help declutter the output